### PR TITLE
feat(chat): Add file upload and image support to chat interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ next-env.d.ts
 
 # Self-hosted Monaco Editor (copied from node_modules)
 public/monaco-editor/
+
+# File uploads
+.claude-uploads/

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_FILES } from '@/types/upload';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const files = formData.getAll('files') as File[];
+    const sessionId = formData.get('sessionId') as string;
+
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Session ID required' }, { status: 400 });
+    }
+
+    // Validate file count
+    if (files.length === 0) {
+      return NextResponse.json({ error: 'No files provided' }, { status: 400 });
+    }
+
+    if (files.length > MAX_FILES) {
+      return NextResponse.json({ error: `Maximum ${MAX_FILES} files allowed` }, { status: 400 });
+    }
+
+    // Validate individual file sizes and calculate total
+    let totalSize = 0;
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        return NextResponse.json(
+          { error: `File ${file.name} exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit` },
+          { status: 400 }
+        );
+      }
+      totalSize += file.size;
+    }
+
+    // Validate total size
+    if (totalSize > MAX_TOTAL_SIZE) {
+      return NextResponse.json(
+        { error: `Total size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit` },
+        { status: 400 }
+      );
+    }
+
+    // Create upload directory
+    const uploadDir = join('/workspace', '.claude-uploads', sessionId);
+    await mkdir(uploadDir, { recursive: true });
+
+    // Save files and collect results
+    const results = await Promise.all(
+      files.map(async (file) => {
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const ext = file.name.substring(file.name.lastIndexOf('.'));
+        const uuid = uuidv4();
+        const filename = `${uuid}${ext}`;
+        const savedPath = join(uploadDir, filename);
+
+        await writeFile(savedPath, buffer);
+
+        return {
+          id: uuid,
+          originalName: file.name,
+          savedPath,
+          size: file.size,
+          type: file.type,
+        };
+      })
+    );
+
+    return NextResponse.json({ files: results });
+  } catch (error) {
+    console.error('Upload error:', error);
+    return NextResponse.json(
+      { error: 'Failed to upload files' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/uploads/cleanup/route.ts
+++ b/src/app/api/uploads/cleanup/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readdir, stat, unlink, rmdir } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+const UPLOAD_BASE_DIR = '/workspace/.claude-uploads';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+async function cleanupDirectory(dirPath: string): Promise<{ filesDeleted: number; dirsDeleted: number }> {
+  let filesDeleted = 0;
+  let dirsDeleted = 0;
+
+  if (!existsSync(dirPath)) {
+    return { filesDeleted, dirsDeleted };
+  }
+
+  const entries = await readdir(dirPath);
+  const now = Date.now();
+
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    const stats = await stat(fullPath);
+
+    if (stats.isDirectory()) {
+      // Recursively clean subdirectory
+      const subResult = await cleanupDirectory(fullPath);
+      filesDeleted += subResult.filesDeleted;
+      dirsDeleted += subResult.dirsDeleted;
+
+      // Try to remove directory if empty
+      try {
+        const remaining = await readdir(fullPath);
+        if (remaining.length === 0) {
+          await rmdir(fullPath);
+          dirsDeleted++;
+        }
+      } catch {
+        // Directory not empty or other error, skip
+      }
+    } else {
+      // Check file age
+      const fileAge = now - stats.mtimeMs;
+      if (fileAge > MAX_AGE_MS) {
+        await unlink(fullPath);
+        filesDeleted++;
+      }
+    }
+  }
+
+  return { filesDeleted, dirsDeleted };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const result = await cleanupDirectory(UPLOAD_BASE_DIR);
+
+    return NextResponse.json({
+      success: true,
+      filesDeleted: result.filesDeleted,
+      dirsDeleted: result.dirsDeleted,
+    });
+  } catch (error) {
+    console.error('Cleanup error:', error);
+    return NextResponse.json(
+      { error: 'Failed to cleanup uploads' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/uploads/serve/route.ts
+++ b/src/app/api/uploads/serve/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import { join, normalize, resolve } from 'path';
+import { existsSync } from 'fs';
+
+const UPLOAD_BASE_DIR = '/workspace/.claude-uploads';
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const path = searchParams.get('path');
+
+    if (!path) {
+      return NextResponse.json({ error: 'Path parameter required' }, { status: 400 });
+    }
+
+    // Security: Ensure path is within upload directory
+    const normalizedPath = normalize(path);
+    const resolvedPath = resolve(normalizedPath);
+    const resolvedBaseDir = resolve(UPLOAD_BASE_DIR);
+
+    if (!resolvedPath.startsWith(resolvedBaseDir)) {
+      return NextResponse.json({ error: 'Invalid path' }, { status: 403 });
+    }
+
+    // Check if file exists
+    if (!existsSync(resolvedPath)) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    // Read file
+    const buffer = await readFile(resolvedPath);
+
+    // Determine content type from file extension
+    const ext = path.substring(path.lastIndexOf('.')).toLowerCase();
+    const contentTypeMap: Record<string, string> = {
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp',
+      '.pdf': 'application/pdf',
+      '.txt': 'text/plain',
+      '.md': 'text/markdown',
+      '.json': 'application/json',
+      '.csv': 'text/csv',
+    };
+    const contentType = contentTypeMap[ext] || 'application/octet-stream';
+
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  } catch (error) {
+    console.error('File serve error:', error);
+    return NextResponse.json(
+      { error: 'Failed to serve file' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,10 @@ export default function Home() {
   const { messages, sendMessage, isStreaming } = useClaudeChat();
   const { error, sidebarOpen, isLoadingHistory } = useChatStore();
 
+  const handleSend = (message: string, attachments?: any) => {
+    sendMessage(message, undefined, attachments);
+  };
+
   return (
     <div className="flex h-screen overflow-hidden bg-white dark:bg-gray-900">
       <Sidebar />
@@ -22,7 +26,7 @@ export default function Home() {
         )}
         <MessageList messages={messages} isLoadingHistory={isLoadingHistory} />
         <UsageDisplay />
-        <ChatInput onSend={sendMessage} disabled={isStreaming} />
+        <ChatInput onSend={handleSend} disabled={isStreaming} />
       </div>
     </div>
   );

--- a/src/components/chat/AttachmentPreview.tsx
+++ b/src/components/chat/AttachmentPreview.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { FileAttachment } from '@/types/upload';
+import { X, Image, File, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+
+interface AttachmentPreviewProps {
+  attachments: FileAttachment[];
+  onRemove: (id: string) => void;
+}
+
+export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewProps) {
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  };
+
+  const getStatusIcon = (status: FileAttachment['uploadStatus']) => {
+    switch (status) {
+      case 'pending':
+        return null;
+      case 'uploading':
+        return <Loader2 className="h-4 w-4 animate-spin text-primary" />;
+      case 'uploaded':
+        return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+      case 'error':
+        return <AlertCircle className="h-4 w-4 text-destructive" />;
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-2 p-2 border border-border rounded-lg bg-muted/30">
+      {attachments.map((attachment) => (
+        <div
+          key={attachment.id}
+          className="relative flex items-center gap-2 p-2 pr-8 rounded-md bg-background border border-border hover:border-primary transition-colors"
+        >
+          {/* Preview/Icon */}
+          <div className="flex-shrink-0 w-12 h-12 rounded overflow-hidden bg-muted flex items-center justify-center">
+            {attachment.isImage && attachment.preview ? (
+              <img
+                src={attachment.preview}
+                alt={attachment.name}
+                className="w-full h-full object-cover"
+              />
+            ) : attachment.isImage ? (
+              <Image className="h-6 w-6 text-muted-foreground" />
+            ) : (
+              <File className="h-6 w-6 text-muted-foreground" />
+            )}
+          </div>
+
+          {/* File info */}
+          <div className="flex flex-col min-w-0 max-w-[200px]">
+            <p className="text-sm font-medium truncate">{attachment.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatFileSize(attachment.size)}
+            </p>
+            {attachment.error && (
+              <p className="text-xs text-destructive truncate">{attachment.error}</p>
+            )}
+          </div>
+
+          {/* Status icon */}
+          {getStatusIcon(attachment.uploadStatus) && (
+            <div className="absolute top-2 right-8">
+              {getStatusIcon(attachment.uploadStatus)}
+            </div>
+          )}
+
+          {/* Remove button */}
+          <button
+            onClick={() => onRemove(attachment.id)}
+            className="absolute top-2 right-2 p-0.5 rounded-full hover:bg-destructive/10 transition-colors"
+            disabled={attachment.uploadStatus === 'uploading'}
+          >
+            <X className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,19 +1,27 @@
 'use client';
 
-import { useState, KeyboardEvent } from 'react';
+import { useState, useRef, KeyboardEvent, DragEvent } from 'react';
+import { Paperclip } from 'lucide-react';
+import { useFileUpload } from '@/hooks/useFileUpload';
+import { AttachmentPreview } from './AttachmentPreview';
+import { FileAttachment } from '@/types/upload';
 
 interface ChatInputProps {
-  onSend: (message: string) => void;
+  onSend: (message: string, attachments?: FileAttachment[]) => void;
   disabled?: boolean;
 }
 
 export function ChatInput({ onSend, disabled }: ChatInputProps) {
   const [input, setInput] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { attachments, addFiles, removeAttachment, clearAttachments } = useFileUpload();
 
   const handleSend = () => {
     if (input.trim() && !disabled) {
-      onSend(input.trim());
+      onSend(input.trim(), attachments.length > 0 ? attachments : undefined);
       setInput('');
+      clearAttachments();
     }
   };
 
@@ -24,29 +32,108 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     }
   };
 
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      try {
+        await addFiles(e.target.files);
+      } catch (error: any) {
+        alert(error.message || 'Failed to add files');
+      }
+      // Reset input so same file can be selected again
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+
+  const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      try {
+        await addFiles(e.dataTransfer.files);
+      } catch (error: any) {
+        alert(error.message || 'Failed to add files');
+      }
+    }
+  };
+
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
-      <div className="flex gap-2">
-        <textarea
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Ask Claude Code... (Cmd/Ctrl+Enter to send)"
-          className="flex-1 resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
-          rows={3}
-          disabled={disabled}
-        />
-        <button
-          onClick={handleSend}
-          disabled={disabled || !input.trim()}
-          className="rounded-lg bg-blue-600 dark:bg-blue-500 px-6 py-3 text-sm font-medium text-white hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50"
-        >
-          Send
-        </button>
+      <div
+        className="relative"
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {/* Drag overlay */}
+        {isDragging && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-blue-500 bg-blue-500/10 backdrop-blur-sm">
+            <p className="text-lg font-medium text-blue-600 dark:text-blue-400">
+              Drop files here
+            </p>
+          </div>
+        )}
+
+        {/* Attachment preview */}
+        <AttachmentPreview attachments={attachments} onRemove={removeAttachment} />
+
+        <div className="flex gap-2">
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={handleFileSelect}
+            accept="image/*,text/*,application/pdf,.txt,.md,.json,.csv"
+          />
+
+          {/* Attach button */}
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled}
+            className="flex-shrink-0 p-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+            title="Attach files"
+          >
+            <Paperclip className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+          </button>
+
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask Claude Code... (Cmd/Ctrl+Enter to send)"
+            className="flex-1 resize-none rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+            rows={3}
+            disabled={disabled}
+          />
+          <button
+            onClick={handleSend}
+            disabled={disabled || !input.trim()}
+            className="rounded-lg bg-blue-600 dark:bg-blue-500 px-6 py-3 text-sm font-medium text-white hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50"
+          >
+            Send
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Press Cmd/Ctrl+Enter to send
+        </p>
       </div>
-      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-        Press Cmd/Ctrl+Enter to send
-      </p>
     </div>
   );
 }

--- a/src/components/chat/ImageThumbnail.tsx
+++ b/src/components/chat/ImageThumbnail.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface ImageThumbnailProps {
+  path: string;
+  originalName: string;
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+export function ImageThumbnail({
+  path,
+  originalName,
+  maxWidth = 300,
+  maxHeight = 200,
+}: ImageThumbnailProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const imageUrl = `/api/uploads/serve?path=${encodeURIComponent(path)}`;
+
+  return (
+    <>
+      <div className="inline-block">
+        <button
+          onClick={() => setIsExpanded(true)}
+          className="relative block overflow-hidden rounded-lg border border-border bg-background hover:border-primary transition-colors"
+          style={{ maxWidth, maxHeight }}
+        >
+          {isLoading && (
+            <div
+              className="flex items-center justify-center bg-muted"
+              style={{ width: maxWidth, height: maxHeight }}
+            >
+              <div className="text-muted-foreground text-sm">Loading...</div>
+            </div>
+          )}
+          {hasError && (
+            <div
+              className="flex items-center justify-center bg-destructive/10"
+              style={{ width: maxWidth, height: maxHeight }}
+            >
+              <div className="text-destructive text-sm">Failed to load</div>
+            </div>
+          )}
+          <img
+            src={imageUrl}
+            alt={originalName}
+            className="max-w-full max-h-full object-contain"
+            style={{ display: isLoading ? 'none' : 'block' }}
+            onLoad={() => setIsLoading(false)}
+            onError={() => {
+              setIsLoading(false);
+              setHasError(true);
+            }}
+          />
+        </button>
+        <p className="mt-1 text-xs text-muted-foreground truncate" style={{ maxWidth }}>
+          {originalName}
+        </p>
+      </div>
+
+      {/* Expanded modal */}
+      {isExpanded && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          onClick={() => setIsExpanded(false)}
+        >
+          <div className="relative max-w-[90vw] max-h-[90vh]">
+            <button
+              onClick={() => setIsExpanded(false)}
+              className="absolute -top-10 right-0 p-2 text-white hover:text-gray-300 transition-colors"
+            >
+              <X className="h-6 w-6" />
+            </button>
+            <img
+              src={imageUrl}
+              alt={originalName}
+              className="max-w-full max-h-[90vh] object-contain rounded-lg"
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/chat/MessageContent.tsx
+++ b/src/components/chat/MessageContent.tsx
@@ -2,6 +2,7 @@
 
 import { MessageContent as MessageContentType } from '@/types/claude';
 import { ToolExecution } from './ToolExecution';
+import { ImageThumbnail } from './ImageThumbnail';
 import { useChatStore } from '@/lib/store';
 
 interface MessageContentProps {
@@ -19,6 +20,14 @@ export function MessageContent({ content }: MessageContentProps) {
             <div key={index} className="whitespace-pre-wrap">
               {block.text}
             </div>
+          );
+        } else if (block.type === 'image' && block.source) {
+          return (
+            <ImageThumbnail
+              key={index}
+              path={block.source.path}
+              originalName={block.source.originalName}
+            />
           );
         } else if (block.type === 'tool_use') {
           // Look up actual tool execution data from store

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,0 +1,99 @@
+import { useState, useCallback } from 'react';
+import { FileAttachment, MAX_FILE_SIZE, MAX_TOTAL_SIZE, MAX_FILES, IMAGE_EXTENSIONS } from '@/types/upload';
+import { v4 as uuidv4 } from 'uuid';
+
+export function useFileUpload() {
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+
+  const isImageFile = (filename: string): boolean => {
+    const ext = filename.substring(filename.lastIndexOf('.')).toLowerCase();
+    return IMAGE_EXTENSIONS.includes(ext);
+  };
+
+  const generatePreview = async (file: File): Promise<string | undefined> => {
+    if (!file.type.startsWith('image/')) {
+      return undefined;
+    }
+
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        resolve(reader.result as string);
+      };
+      reader.onerror = () => {
+        resolve(undefined);
+      };
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const addFiles = useCallback(async (files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+
+    // Validate file count
+    if (attachments.length + fileArray.length > MAX_FILES) {
+      throw new Error(`Maximum ${MAX_FILES} files allowed`);
+    }
+
+    // Validate individual file sizes
+    for (const file of fileArray) {
+      if (file.size > MAX_FILE_SIZE) {
+        throw new Error(`File ${file.name} exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
+      }
+    }
+
+    // Validate total size
+    const currentTotal = attachments.reduce((sum, att) => sum + att.size, 0);
+    const newTotal = fileArray.reduce((sum, file) => sum + file.size, 0);
+    if (currentTotal + newTotal > MAX_TOTAL_SIZE) {
+      throw new Error(`Total size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`);
+    }
+
+    // Create attachments with previews
+    const newAttachments = await Promise.all(
+      fileArray.map(async (file) => {
+        const preview = await generatePreview(file);
+        const attachment: FileAttachment = {
+          id: uuidv4(),
+          file,
+          name: file.name,
+          size: file.size,
+          type: file.type,
+          isImage: isImageFile(file.name),
+          preview,
+          uploadStatus: 'pending',
+        };
+        return attachment;
+      })
+    );
+
+    setAttachments((prev) => [...prev, ...newAttachments]);
+  }, [attachments]);
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((att) => att.id !== id));
+  }, []);
+
+  const clearAttachments = useCallback(() => {
+    setAttachments([]);
+  }, []);
+
+  const updateAttachmentStatus = useCallback(
+    (id: string, status: FileAttachment['uploadStatus'], error?: string, uploadedPath?: string) => {
+      setAttachments((prev) =>
+        prev.map((att) =>
+          att.id === id ? { ...att, uploadStatus: status, error, uploadedPath } : att
+        )
+      );
+    },
+    []
+  );
+
+  return {
+    attachments,
+    addFiles,
+    removeAttachment,
+    clearAttachments,
+    updateAttachmentStatus,
+  };
+}

--- a/src/types/claude.ts
+++ b/src/types/claude.ts
@@ -44,7 +44,7 @@ export interface SDKMessage {
   };
 }
 
-export type ContentBlockType = 'text' | 'tool_use' | 'tool_result';
+export type ContentBlockType = 'text' | 'tool_use' | 'tool_result' | 'image';
 
 export interface MessageContent {
   type: ContentBlockType;
@@ -55,6 +55,7 @@ export interface MessageContent {
   content?: string | any[];
   tool_use_id?: string;
   is_error?: boolean;
+  source?: { type: 'file'; path: string; originalName: string };
 }
 
 export interface ChatMessage {

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -1,0 +1,17 @@
+export interface FileAttachment {
+  id: string;
+  file: File;
+  name: string;
+  size: number;
+  type: string;
+  isImage: boolean;
+  preview?: string;              // Data URL for client preview
+  uploadedPath?: string;         // Server path after upload
+  uploadStatus: 'pending' | 'uploading' | 'uploaded' | 'error';
+  error?: string;
+}
+
+export const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+export const MAX_FILE_SIZE = 10 * 1024 * 1024;      // 10MB per file
+export const MAX_TOTAL_SIZE = 20 * 1024 * 1024;     // 20MB total
+export const MAX_FILES = 10;


### PR DESCRIPTION
Implement comprehensive file upload functionality with drag-and-drop support and image preview capabilities. Files are uploaded to server storage and referenced in prompts for Claude to read.

Features:
- Drag-and-drop file attachment with visual overlay
- File picker with paperclip button in chat input
- Image thumbnail previews with click-to-expand modal
- Support for multiple file types (images, text, PDF, JSON, CSV)
- File validation (10MB per file, 20MB total, max 10 files)
- Upload status indicators (pending, uploading, uploaded, error)
- Secure file serving with path validation
- Automatic cleanup API for old uploads (24hr retention)

Infrastructure:
- FileAttachment type system with upload state management
- useFileUpload hook for client-side attachment handling
- Upload API endpoints (/api/upload, /api/uploads/serve, /api/uploads/cleanup)
- Integration with Claude CLI via enhanced prompts with file references
- Image content blocks for display in user messages

Files uploaded to /workspace/.claude-uploads/{sessionId}/ and referenced in prompts so Claude uses Read tool to view them.