### PR TITLE
fix: Replace echo buffering with spinner overlay

### DIFF
--- a/scripts/terminal-server.ts
+++ b/scripts/terminal-server.ts
@@ -115,16 +115,8 @@ wss.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
       switch (message.type) {
         case 'input':
           if (message.data) {
-            if (message.suppressEcho) {
-              // Clear current line before sending command to hide the echo
-              // \r moves to beginning, \x1b[K clears from cursor to end of line
-              const clearLine = '\r\x1b[K';
-              const wrappedCommand = `${clearLine}${message.data}`;
-              ptyManager.write(sessionId, wrappedCommand);
-              log.debug('Sent input with cleared echo', { sessionId });
-            } else {
-              ptyManager.write(sessionId, message.data);
-            }
+            // Simply write to PTY - no special handling
+            ptyManager.write(sessionId, message.data);
           }
           break;
 

--- a/src/components/terminal/InteractiveTerminal.tsx
+++ b/src/components/terminal/InteractiveTerminal.tsx
@@ -27,7 +27,9 @@ export function InteractiveTerminal({
   onError,
 }: InteractiveTerminalProps) {
   const { resolvedTheme } = useAppTheme();
-  const [hasReceivedOutput, setHasReceivedOutput] = useState(!initialCommand); // Show immediately if no initial command
+  const [isReady, setIsReady] = useState(!initialCommand); // Ready immediately if no command
+  const outputAccumulatorRef = useRef('');
+  const detectionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const {
     terminalRef,
@@ -43,11 +45,29 @@ export function InteractiveTerminal({
     onConnected,
     onDisconnected,
     onError,
-    suppressInitialEcho: !!initialCommand, // Suppress echo when using initial command
     onData: (data) => {
-      // Show terminal once we receive any data (the hook handles buffering)
-      if (!hasReceivedOutput) {
-        setHasReceivedOutput(true);
+      if (!isReady && initialCommand) {
+        outputAccumulatorRef.current += data;
+
+        // Check for Claude patterns
+        const hasClaudeSignature =
+          outputAccumulatorRef.current.includes('Claude Code') ||
+          outputAccumulatorRef.current.includes('▐▛███▜') ||
+          outputAccumulatorRef.current.includes('claude.ai');
+
+        if (hasClaudeSignature) {
+          // Clear timeout and reveal terminal
+          if (detectionTimeoutRef.current) {
+            clearTimeout(detectionTimeoutRef.current);
+            detectionTimeoutRef.current = null;
+          }
+          // Small delay to let Claude's output accumulate
+          setTimeout(() => {
+            const xtermElement = terminalRef.current?.querySelector('.xterm') as HTMLElement | null;
+            xtermElement?.focus();
+            setIsReady(true);
+          }, 100);
+        }
       }
     },
   });
@@ -78,6 +98,21 @@ export function InteractiveTerminal({
       disconnect();
     };
   }, []); // connect/disconnect are stable refs from useTerminal
+
+  // Set timeout fallback when initial command is present
+  useEffect(() => {
+    if (initialCommand && !isReady) {
+      detectionTimeoutRef.current = setTimeout(() => {
+        setIsReady(true); // Show anyway after 3 seconds
+      }, 3000);
+    }
+    return () => {
+      if (detectionTimeoutRef.current) {
+        clearTimeout(detectionTimeoutRef.current);
+        detectionTimeoutRef.current = null;
+      }
+    };
+  }, [initialCommand, isReady]);
 
   return (
     <div
@@ -115,25 +150,25 @@ export function InteractiveTerminal({
         </div>
       )}
 
-      {/* Loading spinner - shown until we receive terminal output */}
-      {!hasReceivedOutput && !error && (
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+      {/* Terminal container - always renders and receives data */}
+      <div
+        ref={terminalRef}
+        className={`h-full w-full transition-opacity duration-300 ${
+          isReady ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+
+      {/* Loading spinner overlay - completely covers terminal until ready */}
+      {!isReady && !error && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
           <div className="flex flex-col items-center gap-3">
             <div className="animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full" />
-            <span className="text-sm text-gray-600 dark:text-gray-400">
+            <span className="text-sm text-gray-400">
               Starting Claude session...
             </span>
           </div>
         </div>
       )}
-
-      {/* Terminal container - hidden until we receive output */}
-      <div
-        ref={terminalRef}
-        className={`h-full w-full transition-opacity duration-300 ${
-          hasReceivedOutput ? 'opacity-100' : 'opacity-0'
-        }`}
-      />
     </div>
   );
 }

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -13,7 +13,6 @@ interface UseTerminalOptions {
   onDisconnected?: () => void;
   onError?: (error: string) => void;
   onData?: (data: string) => void; // Called when terminal receives data
-  suppressInitialEcho?: boolean; // If true, buffer output until Claude starts
 }
 
 interface UseTerminalReturn {
@@ -26,7 +25,7 @@ interface UseTerminalReturn {
 }
 
 export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn {
-  const { cwd, theme = 'dark', initialCommand, onConnected, onDisconnected, onError, onData, suppressInitialEcho = false } = options;
+  const { cwd, theme = 'dark', initialCommand, onConnected, onDisconnected, onError, onData } = options;
 
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
@@ -36,8 +35,6 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isMountedRef = useRef(true);
   const initialCommandSentRef = useRef(false);
-  const outputBufferRef = useRef<string>('');
-  const shouldDisplayOutputRef = useRef(!suppressInitialEcho); // Start false if suppressing
 
   const [isConnected, setIsConnected] = useState(false);
   const isConnectedRef = useRef(false);
@@ -149,8 +146,7 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
                 setTimeout(() => {
                   // Only mark as sent AFTER verifying connection is still active
                   if (wsClientRef.current?.isConnected()) {
-                    // Suppress echo for initial command to avoid showing it twice
-                    wsClientRef.current.sendInput(initialCommand, { suppressEcho: true });
+                    wsClientRef.current.sendInput(initialCommand);
                     initialCommandSentRef.current = true;
                   }
                   // If disconnected during 100ms, ref stays false, retry on next onConnected
@@ -158,42 +154,11 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalReturn
               }
             },
             onData: (data: string) => {
-              if (suppressInitialEcho && !shouldDisplayOutputRef.current) {
-                // Buffer output and check if we should start displaying
-                outputBufferRef.current += data;
+              // Always write data directly to xterm - no buffering
+              xtermRef.current?.write(data);
 
-                // Detect Claude's output patterns
-                if (
-                  outputBufferRef.current.includes('Claude') ||
-                  outputBufferRef.current.includes('▐▛███▜▌') || // Claude logo
-                  outputBufferRef.current.length > 500 // Or substantial output
-                ) {
-                  // Found Claude output! Start displaying from this point
-                  shouldDisplayOutputRef.current = true;
-
-                  // Find where Claude's output starts and only write from there
-                  const claudeIndex = Math.max(
-                    outputBufferRef.current.indexOf('Claude'),
-                    outputBufferRef.current.indexOf('▐▛███▜▌'),
-                    0
-                  );
-
-                  // Write everything from Claude's output onward
-                  const relevantOutput = outputBufferRef.current.substring(claudeIndex);
-                  if (relevantOutput) {
-                    xtermRef.current?.write(relevantOutput);
-                  }
-
-                  // Clear buffer
-                  outputBufferRef.current = '';
-                }
-                // Otherwise, keep buffering (don't write to terminal yet)
-              } else {
-                // Normal mode or already started displaying
-                xtermRef.current?.write(data);
-              }
-
-              onData?.(data); // Always notify parent component of data
+              // Notify parent for detection logic
+              onData?.(data);
             },
             onError: (errorMsg: string) => {
               // Check if still mounted before updating state

--- a/src/lib/terminal/websocket-client.ts
+++ b/src/lib/terminal/websocket-client.ts
@@ -205,7 +205,7 @@ export class WebSocketClient {
   /**
    * Send input to terminal
    */
-  sendInput(data: string, options?: { suppressEcho?: boolean }): void {
+  sendInput(data: string): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       log.error('Cannot send input - WebSocket not connected', {
         readyState: this.ws?.readyState,
@@ -218,8 +218,7 @@ export class WebSocketClient {
     if (data.includes('claude')) {
       log.info('Sending Claude CLI command to terminal', {
         command: data.trim(),
-        sessionId: this.sessionId?.slice(0, 8) || 'none',
-        suppressEcho: options?.suppressEcho || false
+        sessionId: this.sessionId?.slice(0, 8) || 'none'
       });
     } else {
       log.debug('Sending input to terminal', { dataLength: data.length });
@@ -228,7 +227,6 @@ export class WebSocketClient {
     const message: TerminalClientMessage = {
       type: 'input',
       data,
-      suppressEcho: options?.suppressEcho,
     };
 
     this.ws.send(JSON.stringify(message));

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -31,7 +31,6 @@ export type TerminalMessage =
 export interface TerminalInputMessage {
   type: 'input';
   data: string;
-  suppressEcho?: boolean; // If true, temporarily disable terminal echo for this input
 }
 
 export interface TerminalResizeMessage {
@@ -99,5 +98,4 @@ export interface TerminalClientMessage {
   data?: string;
   cols?: number;
   rows?: number;
-  suppressEcho?: boolean; // If true, temporarily disable terminal echo for this input
 }


### PR DESCRIPTION
## Summary
- Replaces client-side echo buffering with visual overlay approach for interactive terminal
- Terminal receives all data immediately (no risk of truncation)
- Opaque spinner overlay hides command echo until Claude is detected
- Multiple detection patterns: Claude Code, ASCII logo, claude.ai URL
- 3-second timeout fallback ensures terminal always reveals
- Removes all `suppressEcho` logic from codebase (server, hooks, types)

## Test plan
- [ ] Click "Interactive" on Bash tool output with Claude command
- [ ] Verify spinner appears: "Starting Claude session..."
- [ ] Spinner visible for 0.5-2s while initialization happens
- [ ] Terminal smoothly fades in once Claude starts
- [ ] Command echo not visible (hidden by overlay during startup)
- [ ] Timeout fallback works (terminal shows after 3s if Claude fails)
- [ ] Can interact with Claude normally after reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)