### PR TITLE
Fix CommandPalette deduplication, CLI init, and export formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,42 @@ Two distinct terminal components serve different purposes:
 ### Learnings
 <!-- Updated during multi-agent execution -->
 
+#### CommandPalette Deduplication & CLI Initialization Fix (2026-02-22)
+- **Problem 1**: ~130 React duplicate key warnings when opening CommandPalette
+  * Root cause: CLI returns commands in both `skills` and `slash_commands` arrays (all skills are also valid slash commands)
+  * CommandPalette combined three sources without deduplication: LOCAL_COMMAND_INFO, availableSkills, availableCommands
+  * Both skills and commands get `/` prefix added, creating duplicate keys like `/commit`, `/debug`, etc.
+- **Problem 2**: CommandPalette showed only 12 local commands, missing all skills/CLI commands
+  * Root cause: `availableSkills` and `availableCommands` were empty arrays
+  * CLI prewarm only ran when creating NEW chat (SessionPanel.tsx:48), not when loading existing sessions
+  * When switching to existing session, only messages/tool executions loaded - skills/commands never restored
+  * Skills and commands are **global to CLI** (not session-specific), should be loaded once on app startup
+- **Solution 1 - Deduplication**: Added filter to remove duplicate commands with priority order
+  * Priority: Local commands (highest) → Skills (middle) → CLI commands (lowest)
+  * Filter keeps first occurrence: `uniqueCommands.filter((cmd, index, self) => index === self.findIndex(c => c.command === cmd.command))`
+  * Added debug logging to track deduplication (shows counts, duplicates removed, samples)
+- **Solution 2 - App-Level Initialization**: Added CLI prewarm on app mount
+  * Added useEffect in `src/app/page.tsx` that runs once on mount
+  * Uses existing sessionId if available, otherwise generates temporary session with valid UUID (`uuidv4()`)
+  * Checks if skills/commands already loaded to avoid duplicate initialization
+  * Uses hasInitialized ref to ensure one-time execution
+  * **Important**: CLI requires pure UUID format - prefixes like `init-${uuid}` are rejected
+- **Files Modified**:
+  * `src/components/chat/CommandPalette.tsx` - Added deduplication logic, debug logging with createLogger
+  * `src/app/page.tsx` - Added app-level CLI initialization on mount
+- **Key Insights**:
+  * Skills appearing in both arrays is expected behavior (all skills are slash commands)
+  * Global CLI metadata (skills, commands, tools) should load on app startup, not per-session
+  * Session switching should only load session-specific data (messages, tool executions, usage)
+  * When debugging React warnings, enable debug mode first to see actual data flow
+- **Verification Steps**:
+  1. Refresh browser with existing session loaded
+  2. Enable debug mode: `enableDebug()` in console
+  3. Type `/` to open CommandPalette
+  4. Check logs: should show skills/commands loaded, duplicates removed, no React warnings
+  5. Verify command count matches expected total (local + skills + commands - duplicates)
+- **Key Lesson**: Distinguish between **session-specific state** (messages, executions) and **global CLI state** (skills, commands, tools). Global state should initialize once on app load, not per-session. Deduplication is necessary when CLI returns overlapping data structures.
+
 #### Dark Mode Visibility Improvements (2026-02-05)
 - Implemented CSS-only improvements for dark mode UI visibility
 - **Terminal borders**: Changed from `border dark:border-gray-600` to `border-2 dark:border-gray-500` with subtle glow effect `dark:shadow-[0_0_0_1px_rgba(107,114,128,0.3)]` for better visibility against dark terminal background (#1f2937)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { useClaudeChat } from '@/hooks/useClaudeChat';
+import { useCliPrewarm } from '@/hooks/useCliPrewarm';
 import { ChatInput } from '@/components/chat/ChatInput';
 import { MessageList } from '@/components/chat/MessageList';
 import { Sidebar } from '@/components/sidebar/Sidebar';
@@ -14,10 +17,45 @@ import { TodosPanel } from '@/components/panels/TodosPanel';
 import { RenameDialog } from '@/components/panels/RenameDialog';
 import { ToastContainer } from '@/components/ui/ToastContainer';
 import { useChatStore } from '@/lib/store';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('Home');
 
 export default function Home() {
   const { messages, sendMessage, isStreaming } = useClaudeChat();
-  const { error, sidebarOpen, isLoadingHistory, previewOpen, rightPanelOpen } = useChatStore();
+  const { error, sidebarOpen, isLoadingHistory, previewOpen, rightPanelOpen, sessionId, availableSkills, availableCommands } = useChatStore();
+  const { prewarmCli } = useCliPrewarm();
+  const hasInitialized = useRef(false);
+
+  // Initialize CLI on mount to load skills and commands
+  useEffect(() => {
+    // Only initialize once
+    if (hasInitialized.current) {
+      return;
+    }
+
+    // Skip if skills and commands are already loaded
+    if (availableSkills?.length > 0 || availableCommands?.length > 0) {
+      log.debug('Skills/commands already loaded, skipping initialization', {
+        skillsCount: availableSkills?.length,
+        commandsCount: availableCommands?.length,
+      });
+      hasInitialized.current = true;
+      return;
+    }
+
+    // Initialize CLI to get skills and commands
+    // Use current session if available, otherwise create a temporary session with valid UUID
+    const initSessionId = sessionId || uuidv4();
+
+    log.debug('Initializing CLI to load skills and commands', {
+      sessionId: initSessionId,
+      isTemporary: !sessionId,
+    });
+
+    hasInitialized.current = true;
+    prewarmCli(initSessionId);
+  }, [sessionId, availableSkills, availableCommands, prewarmCli]);
 
   const handleSend = (message: string, attachments?: any) => {
     sendMessage(message, undefined, attachments);

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -86,7 +86,9 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
   // Show/hide command palette based on input
   useEffect(() => {
     const trimmed = input.trim();
-    if (trimmed.startsWith('/') && trimmed.length > 0) {
+    // Show palette if input starts with / and doesn't end with a space
+    // (ending with space means a command was just selected)
+    if (trimmed.startsWith('/') && trimmed.length > 0 && !input.endsWith(' ')) {
       setShowCommandPalette(true);
     } else {
       setShowCommandPalette(false);
@@ -164,30 +166,330 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           setModelPanelOpen(true);
           break;
         case 'exportConversation': {
-          // Export messages as JSON
-          const exportData = {
-            sessionId: currentSession?.id,
-            sessionName: currentSession?.name,
-            exportedAt: new Date().toISOString(),
-            messages: messages.map(m => ({
-              role: m.role,
-              content: m.content,
-              timestamp: m.timestamp
-            }))
-          };
-          const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-            type: 'application/json'
-          });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          const filename = currentSession?.name
-            ? `${currentSession.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${Date.now()}.json`
-            : `conversation-${Date.now()}.json`;
-          a.download = filename;
-          a.click();
-          URL.revokeObjectURL(url);
-          showToast('Exported conversation', 'success');
+          // Check export format (e.g., "/export json", "/export markdown")
+          const inputLower = trimmed.toLowerCase();
+          const wantsJson = inputLower.includes('json');
+          const wantsMarkdown = inputLower.includes('markdown') || inputLower.includes('md');
+
+          if (wantsJson) {
+            // Export as JSON
+            const exportData = {
+              sessionId: currentSession?.id,
+              sessionName: currentSession?.name,
+              exportedAt: new Date().toISOString(),
+              messages: messages.map(m => ({
+                role: m.role,
+                content: m.content,
+                timestamp: m.timestamp
+              }))
+            };
+            const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+              type: 'application/json'
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            const filename = currentSession?.name
+              ? `${currentSession.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${Date.now()}.json`
+              : `conversation-${Date.now()}.json`;
+            a.download = filename;
+            a.click();
+            URL.revokeObjectURL(url);
+            showToast('Exported conversation as JSON', 'success');
+          } else if (wantsMarkdown) {
+            // Export as Markdown
+            const formatTimestamp = (ts: number) => {
+              return new Date(ts).toLocaleString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+              });
+            };
+
+            const formatContent = (content: any[]): string => {
+              return content.map(block => {
+                if (typeof block === 'string') {
+                  return block;
+                }
+                if (block.type === 'text') {
+                  return block.text || '';
+                }
+                if (block.type === 'tool_use') {
+                  return `\n**[Tool Use: ${block.name}]**\n\`\`\`json\n${JSON.stringify(block.input, null, 2)}\n\`\`\`\n`;
+                }
+                if (block.type === 'tool_result') {
+                  const content = block.content || block.output || '';
+                  return `\n**[Tool Result]**\n\`\`\`\n${content}\n\`\`\`\n`;
+                }
+                if (block.type === 'thinking') {
+                  return `\n**[Thinking]**\n${block.thinking || ''}\n`;
+                }
+                if (block.type === 'image') {
+                  return `\n**[Image: ${block.source?.type || 'attached'}]**\n`;
+                }
+                return JSON.stringify(block);
+              }).join('\n');
+            };
+
+            const markdown = [
+              `# Conversation Export`,
+              ``,
+              `**Session:** ${currentSession?.name || 'Untitled'}`,
+              `**Session ID:** ${currentSession?.id || 'Unknown'}`,
+              `**Exported:** ${new Date().toLocaleString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+              })}`,
+              `**Messages:** ${messages.length}`,
+              ``,
+              `---`,
+              ``,
+              ...messages.map(msg => {
+                const roleLabel = msg.role === 'user' ? '👤 User' :
+                                msg.role === 'assistant' ? '🤖 Assistant' :
+                                msg.role === 'system' ? '⚙️  System' : msg.role;
+                return [
+                  `## ${roleLabel}`,
+                  `*${formatTimestamp(msg.timestamp)}*`,
+                  ``,
+                  formatContent(msg.content),
+                  ``,
+                  `---`,
+                  ``
+                ].join('\n');
+              })
+            ].join('\n');
+
+            const blob = new Blob([markdown], {
+              type: 'text/markdown'
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            const filename = currentSession?.name
+              ? `${currentSession.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${Date.now()}.md`
+              : `conversation-${Date.now()}.md`;
+            a.download = filename;
+            a.click();
+            URL.revokeObjectURL(url);
+            showToast('Exported conversation as Markdown', 'success');
+          } else {
+            // Export as HTML (default - Word-ready)
+            const formatTimestamp = (ts: number) => {
+              return new Date(ts).toLocaleString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+              });
+            };
+
+            const escapeHtml = (text: string): string => {
+              return text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+            };
+
+            const formatContentHtml = (content: any[]): string => {
+              return content.map(block => {
+                if (typeof block === 'string') {
+                  return `<p>${escapeHtml(block)}</p>`;
+                }
+                if (block.type === 'text') {
+                  const text = block.text || '';
+                  // Preserve line breaks
+                  return `<p>${escapeHtml(text).replace(/\n/g, '<br>')}</p>`;
+                }
+                if (block.type === 'tool_use') {
+                  return `
+                    <div class="tool-block">
+                      <strong>🔧 Tool Use: ${escapeHtml(block.name)}</strong>
+                      <pre><code>${escapeHtml(JSON.stringify(block.input, null, 2))}</code></pre>
+                    </div>`;
+                }
+                if (block.type === 'tool_result') {
+                  const content = block.content || block.output || '';
+                  return `
+                    <div class="tool-block">
+                      <strong>📤 Tool Result</strong>
+                      <pre><code>${escapeHtml(String(content))}</code></pre>
+                    </div>`;
+                }
+                if (block.type === 'thinking') {
+                  return `
+                    <div class="thinking-block">
+                      <strong>💭 Thinking</strong>
+                      <p>${escapeHtml(block.thinking || '').replace(/\n/g, '<br>')}</p>
+                    </div>`;
+                }
+                if (block.type === 'image') {
+                  return `<p><em>🖼️ Image: ${escapeHtml(block.source?.type || 'attached')}</em></p>`;
+                }
+                return `<pre><code>${escapeHtml(JSON.stringify(block))}</code></pre>`;
+              }).join('\n');
+            };
+
+            const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(currentSession?.name || 'Conversation Export')}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      color: #333;
+    }
+    h1 {
+      color: #2563eb;
+      border-bottom: 3px solid #2563eb;
+      padding-bottom: 10px;
+      margin-bottom: 30px;
+    }
+    .meta {
+      background: #f3f4f6;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 30px;
+    }
+    .meta p {
+      margin: 5px 0;
+      color: #6b7280;
+    }
+    .meta strong {
+      color: #374151;
+    }
+    .message {
+      margin: 30px 0;
+      padding: 20px;
+      border-left: 4px solid #e5e7eb;
+      background: #fafafa;
+      border-radius: 4px;
+      page-break-inside: avoid;
+    }
+    .message.user {
+      border-left-color: #3b82f6;
+      background: #eff6ff;
+    }
+    .message.assistant {
+      border-left-color: #10b981;
+      background: #f0fdf4;
+    }
+    .message.system {
+      border-left-color: #f59e0b;
+      background: #fffbeb;
+    }
+    .message-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 15px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .role {
+      font-weight: 600;
+      font-size: 18px;
+    }
+    .timestamp {
+      color: #6b7280;
+      font-size: 14px;
+    }
+    .content p {
+      margin: 10px 0;
+      white-space: pre-wrap;
+    }
+    .tool-block, .thinking-block {
+      margin: 15px 0;
+      padding: 15px;
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+    }
+    .tool-block strong, .thinking-block strong {
+      display: block;
+      margin-bottom: 10px;
+      color: #1f2937;
+    }
+    pre {
+      background: #1f2937;
+      color: #f3f4f6;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      margin: 10px 0;
+    }
+    code {
+      font-family: "Monaco", "Courier New", monospace;
+      font-size: 13px;
+    }
+    @media print {
+      body {
+        padding: 20px;
+      }
+      .message {
+        page-break-inside: avoid;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>📄 Conversation Export</h1>
+  <div class="meta">
+    <p><strong>Session:</strong> ${escapeHtml(currentSession?.name || 'Untitled')}</p>
+    <p><strong>Session ID:</strong> ${escapeHtml(currentSession?.id || 'Unknown')}</p>
+    <p><strong>Exported:</strong> ${formatTimestamp(Date.now())}</p>
+    <p><strong>Messages:</strong> ${messages.length}</p>
+  </div>
+  ${messages.map(msg => {
+    const roleLabel = msg.role === 'user' ? '👤 User' :
+                    msg.role === 'assistant' ? '🤖 Assistant' :
+                    msg.role === 'system' ? '⚙️ System' : escapeHtml(msg.role);
+    const roleClass = msg.role;
+    return `
+      <div class="message ${roleClass}">
+        <div class="message-header">
+          <div class="role">${roleLabel}</div>
+          <div class="timestamp">${formatTimestamp(msg.timestamp)}</div>
+        </div>
+        <div class="content">
+          ${formatContentHtml(msg.content)}
+        </div>
+      </div>`;
+  }).join('\n')}
+</body>
+</html>`;
+
+            const blob = new Blob([html], {
+              type: 'text/html'
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            const filename = currentSession?.name
+              ? `${currentSession.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${Date.now()}.html`
+              : `conversation-${Date.now()}.html`;
+            a.download = filename;
+            a.click();
+            URL.revokeObjectURL(url);
+            showToast('Exported conversation as HTML', 'success');
+          }
           break;
         }
         case 'openTodosPanel':

--- a/src/components/chat/CommandPalette.tsx
+++ b/src/components/chat/CommandPalette.tsx
@@ -4,6 +4,9 @@ import { useEffect, useRef, useState } from 'react';
 import { Terminal, Zap, Package } from 'lucide-react';
 import { LOCAL_COMMAND_INFO, CommandInfo } from '@/lib/commands/router';
 import { useChatStore } from '@/lib/store';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('CommandPalette');
 
 interface CommandPaletteProps {
   inputValue: string;
@@ -16,8 +19,8 @@ export function CommandPalette({ inputValue, onSelectCommand, onClose }: Command
   const [selectedIndex, setSelectedIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // Extract search query (everything after /)
-  const searchQuery = inputValue.slice(1).toLowerCase();
+  // Extract search query (everything after /, trimmed)
+  const searchQuery = inputValue.slice(1).toLowerCase().trim();
 
   // Combine all available commands
   const allCommands: Array<CommandInfo & { type: 'local' | 'skill' | 'command' }> = [
@@ -36,12 +39,39 @@ export function CommandPalette({ inputValue, onSelectCommand, onClose }: Command
     })),
   ];
 
+  log.debug('Combined commands', {
+    inputValue,
+    searchQuery,
+    localCount: LOCAL_COMMAND_INFO.length,
+    skillsCount: availableSkills?.length || 0,
+    commandsCount: availableCommands?.length || 0,
+    totalBeforeDedup: allCommands.length,
+    sampleCommands: allCommands.slice(0, 10).map(c => c.command),
+  });
+
+  // Deduplicate by command name (keeps first occurrence = higher priority)
+  const uniqueCommands = allCommands.filter((cmd, index, self) =>
+    index === self.findIndex(c => c.command === cmd.command)
+  );
+
+  log.debug('After deduplication', {
+    uniqueCount: uniqueCommands.length,
+    duplicatesRemoved: allCommands.length - uniqueCommands.length,
+    sampleUnique: uniqueCommands.slice(0, 10).map(c => c.command),
+  });
+
   // Filter commands based on search query
   const filteredCommands = searchQuery
-    ? allCommands.filter(cmd =>
+    ? uniqueCommands.filter(cmd =>
         cmd.command.toLowerCase().includes(searchQuery)
       )
-    : allCommands;
+    : uniqueCommands;
+
+  log.debug('After filtering', {
+    searchQuery,
+    filteredCount: filteredCommands.length,
+    sampleFiltered: filteredCommands.slice(0, 5).map(c => c.command),
+  });
 
   // Reset selection when filtered list changes
   useEffect(() => {

--- a/src/lib/commands/router.ts
+++ b/src/lib/commands/router.ts
@@ -33,7 +33,7 @@ export const LOCAL_COMMAND_INFO: CommandInfo[] = [
   { command: '/copy', handler: 'copyLastResponse', description: 'Copy last assistant response to clipboard' },
   { command: '/model', handler: 'openModelPanel', description: 'Open model selection panel' },
   { command: '/theme', handler: 'cycleTheme', description: 'Cycle through available themes' },
-  { command: '/export', handler: 'exportConversation', description: 'Export conversation as JSON file' },
+  { command: '/export', handler: 'exportConversation', description: 'Export as HTML (Word-ready), or use "/export json" or "/export markdown"' },
   { command: '/todos', handler: 'openTodosPanel', description: 'Show tasks and todos panel' },
   { command: '/rename', handler: 'openRenameDialog', description: 'Rename the current session' },
 ];


### PR DESCRIPTION
## Summary

This PR fixes three issues with the CommandPalette and adds improved export functionality:

1. **CommandPalette duplicate key warnings** - Deduplicate commands from overlapping skills/slash_commands arrays
2. **CLI initialization bug** - Load skills/commands on app mount, not just when creating new chat
3. **Export formats** - Add HTML (Word-ready) as default, with JSON and Markdown options

## Changes

### CommandPalette Deduplication
- **Problem**: ~130 React duplicate key warnings when opening CommandPalette
- **Cause**: CLI returns all skills in both `skills` and `slash_commands` arrays, creating duplicates
- **Solution**: Added deduplication filter with priority: Local commands → Skills → CLI commands
- **Files**: `src/components/chat/CommandPalette.tsx`

### CLI Initialization Fix
- **Problem**: CommandPalette showed only 12 local commands, missing all skills/CLI commands
- **Cause**: CLI prewarm only ran when creating NEW chat, not when loading existing sessions
- **Solution**: Added app-level CLI initialization on mount in `src/app/page.tsx`
- **Files**: `src/app/page.tsx`

### Export Format Improvements
- **Default**: `/export` now creates Word-ready HTML file with professional styling
- **Options**: `/export json` for JSON, `/export markdown` for Markdown
- **Features**: Color-coded messages, emoji indicators, print-friendly layout
- **Files**: `src/components/chat/ChatInput.tsx`, `src/lib/commands/router.ts`

### Additional Fixes
- Fixed CommandPalette not closing after command selection (trim search query)
- Added debug logging to CommandPalette for troubleshooting

## Verification

- [x] No duplicate key warnings in console when opening CommandPalette
- [x] Full command list shows (60+ commands instead of 12)
- [x] CommandPalette closes properly after selecting command
- [x] `/export` creates HTML file that opens in Word
- [x] `/export json` creates JSON file
- [x] `/export markdown` creates Markdown file
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)